### PR TITLE
Add release notes to versions 4.6.10, 4.8.0.1 and 4.0.18

### DIFF
--- a/index.html
+++ b/index.html
@@ -162,8 +162,8 @@
                 <div class="smaller-margin"><p>Source code:</p></div>
                 <ul>
                     <li><a target="_blank" href="https://github.com/pcengines/coreboot/compare/v4.6.10...v4.8.0.1">coreboot v4.8.0.1</a></li>
-                    <li><a target="_blank" href="https://github.com/pcengines/seabios/compare/rel-1.11.0.4...rel-1.11.0.5">SeaBIOS rel-1.11.0.4</a></li>
-                    <li><a target="_blank" href="https://github.com/pcengines/sortbootorder/compare/v4.6.8...v4.6.9">sortbootorder v4.6.8</a></li>
+                    <li><a target="_blank" href="https://github.com/pcengines/seabios/compare/rel-1.11.0.4...rel-1.11.0.5">SeaBIOS rel-1.11.0.5</a></li>
+                    <li><a target="_blank" href="https://github.com/pcengines/sortbootorder/compare/v4.6.8...v4.6.9">sortbootorder v4.6.9</a></li>
                     <li><a target="_blank" href="https://git.ipxe.org/ipxe.git">ipxe</a></li>
                     <li><a target="_blank" href="https://review.coreboot.org/cgit/memtest86plus.git/">memtest86+ v5.0.1</a></li>
                 </ul>
@@ -209,8 +209,8 @@
                 <div class="smaller-margin"><p>Source code:</p></div>
                 <ul>
                     <li><a target="_blank" href="https://github.com/pcengines/coreboot/compare/v4.6.9...v4.6.10">coreboot v4.6.10</a></li>
-                    <li><a target="_blank" href="https://github.com/pcengines/seabios/compare/rel-1.11.0.4...rel-1.11.0.5">SeaBIOS rel-1.11.0.4</a></li>
-                    <li><a target="_blank" href="https://github.com/pcengines/sortbootorder/compare/v4.6.8...v4.6.9">sortbootorder v4.6.8</a></li>
+                    <li><a target="_blank" href="https://github.com/pcengines/seabios/compare/rel-1.11.0.4...rel-1.11.0.5">SeaBIOS rel-1.11.0.5</a></li>
+                    <li><a target="_blank" href="https://github.com/pcengines/sortbootorder/compare/v4.6.8...v4.6.9">sortbootorder v4.6.9</a></li>
                     <li><a target="_blank" href="https://git.ipxe.org/ipxe.git">ipxe</a></li>
                     <li><a target="_blank" href="https://review.coreboot.org/cgit/memtest86plus.git/">memtest86+ v5.0.1</a></li>
                 </ul>

--- a/index.html
+++ b/index.html
@@ -43,6 +43,8 @@
                 <div class="main-list">
                     <h3>Mainline releases</h3>
                     <ul>
+                        <li><a href="#mr-11">v4.8.0.1</a></li>
+                        <li><a href="#mr-10">v4.6.10</a></li>
                         <li><a href="#mr-9">v4.6.9</a></li>
                         <li><a href="#mr-8">v4.6.8</a></li>
                         <li><a href="#mr-7">v4.6.7</a></li>
@@ -58,6 +60,7 @@
                 <div class="main-list">
                     <h3>Legacy releases</h3>
                     <ul>
+                        <li><a href="#lr-10">v4.0.18</a></li>
                         <li><a href="#lr-9">v4.0.17</a></li>
                         <li><a href="#lr-8">v4.0.16</a></li>
                         <li><a href="#lr-7">v4.0.15</a></li>
@@ -117,15 +120,107 @@
 
 
         <div class="container">
-<!-- mainline releases v4.6.8 -->
+<!-- mainline releases v4.8.0.1 -->
 <!-- 
     <div class="break"></div> 
     insert this code when a new update comes out to separate a new version from the current.
 -->
 
-        <div class="smaller-margin" id="mr-9">
+        <div class="smaller-margin" id="mr-11">
             <h2 class="text-middle">Mainline releases</h2>
             <!-- h2 tag needs to be moved to the newest version -->
+            <h4><a target="_blank" href="https://github.com/pcengines/coreboot/compare/v4.6.9...v4.6.10">v4.8.0.1</a></h4>
+        </div>
+
+        <div class="dimmed-text"><p>Release date: 2018-06-08</p></div>
+
+        <ul>
+            <li>Fixed/added:</li>
+            <ol>
+                <li>Rebased coreboot repository to official coreboot 4.8.0</li>
+            </ol>
+            <li>Known issues:</li>
+            <ol>
+                <li>some PCIe cards are not detected on certain OSes</li>
+                <li>booting with 2 USB 3.x sticks plugged in apu4 sometimes results in detecting only 1 stick</li>
+                <li>certain USB 3.x sticks happen to not appear in boot menu</li>
+            </ol>
+        </ul>
+
+        <div class="source-code-links-binaries">
+            <div class="source-code-column">
+                <div class="smaller-margin"><p>Binaries:</p></div>
+                <ul>
+                    <li><a href="http://pcengines.ch/file/apu1_v4.8.0.1.rom.tar.gz">apu1 v4.8.0.1</a></li>
+                    <li><a href="http://pcengines.ch/file/apu2_v4.8.0.1.rom.tar.gz">apu2 v4.8.0.1</a></li>
+                    <li><a href="http://pcengines.ch/file/apu3_v4.8.0.1.rom.tar.gz">apu3 v4.8.0.1</a></li>
+                    <li><a href="http://pcengines.ch/file/apu4_v4.8.0.1.rom.tar.gz">apu4 v4.8.0.1</a></li>
+                    <li><a href="http://pcengines.ch/file/apu5_v4.8.0.1.rom.tar.gz">apu5 v4.8.0.1</a></li>
+                </ul>
+            </div>
+            <div class="source-code-column">
+                <div class="smaller-margin"><p>Source code:</p></div>
+                <ul>
+                    <li><a target="_blank" href="https://github.com/pcengines/coreboot/compare/v4.6.10...v4.8.0.1">coreboot v4.8.0.1</a></li>
+                    <li><a target="_blank" href="https://github.com/pcengines/seabios/compare/rel-1.11.0.4...rel-1.11.0.5">SeaBIOS rel-1.11.0.4</a></li>
+                    <li><a target="_blank" href="https://github.com/pcengines/sortbootorder/compare/v4.6.8...v4.6.9">sortbootorder v4.6.8</a></li>
+                    <li><a target="_blank" href="https://git.ipxe.org/ipxe.git">ipxe</a></li>
+                    <li><a target="_blank" href="https://review.coreboot.org/cgit/memtest86plus.git/">memtest86+ v5.0.1</a></li>
+                </ul>
+            </div>
+        </div>
+
+        <div class="break"></div> 
+
+
+        <div class="smaller-margin" id="mr-10">
+            <h4><a target="_blank" href="https://github.com/pcengines/coreboot/compare/v4.6.9...v4.6.10">v4.6.10</a></h4>
+        </div>
+
+        <div class="dimmed-text"><p>Release date: 2018-06-08</p></div>
+
+        <ul>
+            <li>Fixed/added:</li>
+            <ol>
+                <li>Updated SeaBIOS to 1.11.0.5</li>
+                <li>Updated sortbootorder to v4.6.9</li>
+                <li>S1 button support for apu5b</li>
+            </ol>
+            <li>Known issues:</li>
+            <ol>
+                <li>some PCIe cards are not detected on certain OSes</li>
+                <li>booting with 2 USB 3.x sticks plugged in apu4 sometimes results in detecting only 1 stick</li>
+                <li>certain USB 3.x sticks happen to not appear in boot menu</li>
+            </ol>
+        </ul>
+
+        <div class="source-code-links-binaries">
+            <div class="source-code-column">
+                <div class="smaller-margin"><p>Binaries:</p></div>
+                <ul>
+                    <li><a href="http://pcengines.ch/file/apu1_v4.6.10.rom.tar.gz">apu1 v4.6.10</a></li>
+                    <li><a href="http://pcengines.ch/file/apu2_v4.6.10.rom.tar.gz">apu2 v4.6.10</a></li>
+                    <li><a href="http://pcengines.ch/file/apu3_v4.6.10.rom.tar.gz">apu3 v4.6.10</a></li>
+                    <li><a href="http://pcengines.ch/file/apu4_v4.6.10.rom.tar.gz">apu4 v4.6.10</a></li>
+                    <li><a href="http://pcengines.ch/file/apu5_v4.6.10.rom.tar.gz">apu5 v4.6.10</a></li>
+                </ul>
+            </div>
+            <div class="source-code-column">
+                <div class="smaller-margin"><p>Source code:</p></div>
+                <ul>
+                    <li><a target="_blank" href="https://github.com/pcengines/coreboot/compare/v4.6.9...v4.6.10">coreboot v4.6.10</a></li>
+                    <li><a target="_blank" href="https://github.com/pcengines/seabios/compare/rel-1.11.0.4...rel-1.11.0.5">SeaBIOS rel-1.11.0.4</a></li>
+                    <li><a target="_blank" href="https://github.com/pcengines/sortbootorder/compare/v4.6.8...v4.6.9">sortbootorder v4.6.8</a></li>
+                    <li><a target="_blank" href="https://git.ipxe.org/ipxe.git">ipxe</a></li>
+                    <li><a target="_blank" href="https://review.coreboot.org/cgit/memtest86plus.git/">memtest86+ v5.0.1</a></li>
+                </ul>
+            </div>
+        </div>
+
+        <div class="break"></div> 
+
+<!-- Mainline Release 4.6.9 -->
+        <div class="smaller-margin" id="mr-9">
             <h4><a target="_blank" href="https://github.com/pcengines/coreboot/compare/v4.6.8...v4.6.9">v4.6.9</a></h4>
         </div>
 
@@ -550,14 +645,60 @@
                                     <!-- LEGACY RELEASES -->
 
         <div class="container">
-<!-- legacy releases v4.0.17 -->
+
+
+<!-- legacy releases v4.0.18 -->
 <!-- 
     <div class="break"></div> 
     insert this code when a new update comes out to separate a new version from the current.
 -->
-        <div class="smaller-margin" id="lr-9">
+        <div class="smaller-margin" id="lr-10">
             <h2 class="text-middle">Legacy releases</h2>
             <!-- h2 tag needs to be moved to the newest version -->
+            <h4><a target="_blank" href="https://github.com/pcengines/coreboot/compare/v4.0.17...v4.0.18">v4.0.18</a></h4>
+        </div>
+
+        <div class="dimmed-text"><p>Release date: 2018-06-08</p></div>
+
+        <ul>
+            <li>Fixed/added:</li>
+            <ol>
+                <li>Updated SeaBIOS to 1.11.0.5</li>
+                <li>Updated sortbootorder to v4.6.9</li>
+                <li>S1 button support for apu5b</li>
+            </ol>
+            <li>Known issues:</li>
+            <ol>
+                <li>certain USB 3.x sticks happen to not appear in boot menu</li>
+            </ol>
+        </ul>
+
+        <div class="source-code-links-binaries">
+            <div class="source-code-column">
+                <div class="smaller-margin"><p>Binaries:</p></div>
+                <ul>
+                    <li><a href="http://pcengines.ch/file/apu2_v4.0.18.rom.tar.gz">apu2 v4.0.18</a></li>
+                    <li><a href="http://pcengines.ch/file/apu3_v4.0.18.rom.tar.gz">apu3 v4.0.18</a></li>
+                    <li><a href="http://pcengines.ch/file/apu4_v4.0.18.rom.tar.gz">apu4 v4.0.18</a></li>
+                    <li><a href="http://pcengines.ch/file/apu5_v4.0.18.rom.tar.gz">apu5 v4.0.18</a></li>
+                </ul>
+            </div>
+            <div class="source-code-column">
+                <div class="smaller-margin"><p>Source code:</p></div>
+                <ul>
+                    <li><a target="_blank" href="https://github.com/pcengines/coreboot/compare/v4.0.17...v4.0.18">coreboot v4.0.18</a></li>
+                    <li><a target="_blank" href="https://github.com/pcengines/seabios/compare/rel-1.11.0.4...rel-1.11.0.5">SeaBIOS rel-1.11.0.5</a></li>
+                    <li><a target="_blank" href="https://github.com/pcengines/sortbootorder/compare/v4.6.5...v4.6.9">sortbootorder v4.6.9</a></li>
+                    <li><a target="_blank" href="https://git.ipxe.org/ipxe.git">ipxe</a></li>
+                    <li><a target="_blank" href="https://github.com/pcengines/memtest86plus/compare/620a64eb50400d315ef411357936e4824a0ac592...v4.0.1">memtest86+ v4.0.1</a></li>
+                </ul>
+            </div>
+        </div>
+
+
+    <div class="break"></div> 
+
+        <div class="smaller-margin" id="lr-9">
             <h4><a target="_blank" href="https://github.com/pcengines/coreboot/compare/v4.0.16...v4.0.17">v4.0.17</a></h4>
         </div>
 
@@ -591,7 +732,7 @@
                 <ul>
                     <li><a target="_blank" href="https://github.com/pcengines/coreboot/compare/v4.0.16...v4.0.17">coreboot v4.0.17</a></li>
                     <li><a target="_blank" href="https://github.com/pcengines/seabios/compare/rel-1.11.0.3...rel-1.11.0.4">SeaBIOS rel-1.11.0.4</a></li>
-                    <li><a target="_blank" href="https://github.com/pcengines/sortbootorder/blob/master/CHANGELOG.md#v465---2017-12-29">sortbootorder v4.6.5</a></li>
+                    <li><a target="_blank" href="https://github.com/pcengines/sortbootorder/compare/v4.5.7...v4.6.5">sortbootorder v4.6.5</a></li>
                     <li><a target="_blank" href="https://git.ipxe.org/ipxe.git">ipxe</a></li>
                     <li><a target="_blank" href="https://github.com/pcengines/memtest86plus/compare/620a64eb50400d315ef411357936e4824a0ac592...v4.0.1">memtest86+ v4.0.1</a></li>
                 </ul>
@@ -634,7 +775,7 @@
                     <ul>
                         <li><a target="_blank" href="https://github.com/pcengines/coreboot/compare/v4.0.15...v4.0.16">coreboot v4.0.16</a></li>
                         <li><a target="_blank" href="https://github.com/pcengines/seabios/compare/rel-1.11.0.3...rel-1.11.0.4">SeaBIOS rel-1.11.0.4</a></li>
-                        <li><a target="_blank" href="https://github.com/pcengines/sortbootorder/blob/master/CHANGELOG.md#v465---2017-12-29">sortbootorder v4.6.5</a></li>
+                        <li><a target="_blank" href="https://github.com/pcengines/sortbootorder/compare/v4.5.7...v4.6.5">sortbootorder v4.6.5</a></li>
                         <li><a target="_blank" href="https://git.ipxe.org/ipxe.git">ipxe</a></li>
                         <li><a target="_blank" href="https://github.com/pcengines/memtest86plus/compare/620a64eb50400d315ef411357936e4824a0ac592...v4.0.1">memtest86+ v4.0.1</a></li>
                     </ul>
@@ -678,7 +819,7 @@
                     <ul>
                         <li><a target="_blank" href="https://github.com/pcengines/coreboot/compare/v4.0.14...v4.0.15">coreboot v4.0.15</a></li>
                         <li><a target="_blank" href="https://github.com/pcengines/seabios/compare/rel-1.11.0.2...rel-1.11.0.3">SeaBIOS rel-1.11.0.3</a></li>
-                        <li><a target="_blank" href="https://github.com/pcengines/sortbootorder/blob/master/CHANGELOG.md#v465---2017-12-29">sortbootorder v4.6.5</a></li>
+                        <li><a target="_blank" href="https://github.com/pcengines/sortbootorder/compare/v4.5.7...v4.6.5">sortbootorder v4.6.5</a></li>
                         <li><a target="_blank" href="https://git.ipxe.org/ipxe.git">ipxe</a></li>
                         <li><a target="_blank" href="https://github.com/pcengines/memtest86plus/compare/620a64eb50400d315ef411357936e4824a0ac592...v4.0.1">memtest86+ v4.0.1</a></li>
                     </ul>


### PR DESCRIPTION
Please mind that links to the new binaries are not available yet.