### PR TITLE
index.html: Add missing canonical

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,6 +23,7 @@
     <link rel="stylesheet" type="text/css" href="css/style.css" />
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="canonical" href="https://pcengines.github.io/" itemprop="url">
     <title>PC Engines - github pages</title>
   </head>
 


### PR DESCRIPTION
The index page is available at two URLs [1] [2].
To avoid a SEO issue, the master page must be pointed in the cannonical tag.

References:

[1] https://pcengines.github.io/
[2] https://pcengines.github.io/index.html